### PR TITLE
Update Activity Permalink template and CSS/LESS

### DIFF
--- a/buddypress/members/single/activity/permalink.php
+++ b/buddypress/members/single/activity/permalink.php
@@ -7,11 +7,13 @@
  */
 ?>
 
+<?php do_action( 'bp_before_single_activity' ); ?>
+
 <div id="buddypress">
 
 	<?php if ( bp_has_activities( 'display_comments=threaded&show_hidden=true&include=' . bp_current_action() ) ) : ?>
 
-		<ul class="bp-archive-activity">
+		<ul class="bp-archive-activity bp-single-activity">
 		
 		<?php while ( bp_activities() ) : bp_the_activity(); ?>
 		
@@ -29,3 +31,4 @@
 
 </div><!-- #buddypress -->
 
+<?php do_action( 'bp_after_single_activity' ); ?>

--- a/css/buddypress.css
+++ b/css/buddypress.css
@@ -5,6 +5,7 @@
 03. Groups Directory
 04. Pagination
 05. Activity Directory
+05a. Activity Permalink
 07. Sites Directory
 08. Single member
 08a. Single member - menu
@@ -271,6 +272,11 @@
 }
 .bp-archive-activity .activity-actions li .has-count span:after {
   content: ")";
+}
+/* =05a. Activity Permalink
+--------------------------------------------------------------- */
+#buddypress .bp-single-activity li {
+  margin: 0;
 }
 /* =06. Sites Directory
 --------------------------------------------------------------- */

--- a/css/buddypress.less
+++ b/css/buddypress.less
@@ -5,6 +5,7 @@
 03. Groups Directory
 04. Pagination
 05. Activity Directory
+05a. Activity Permalink
 07. Sites Directory
 08. Single member
 08a. Single member - menu
@@ -232,6 +233,14 @@
 				span:after { content: ")"; }
 			}
 		}
+	}
+}
+
+/* =05a. Activity Permalink
+--------------------------------------------------------------- */
+#buddypress .bp-single-activity {
+	li {
+		margin: 0;
 	}
 }
 


### PR DESCRIPTION
Added pair of actions and class (new bp-single-activity). Remove bottom
margin in CSS/LESS.

For the CSS/LESS, I added as a sub-category of the "Activity" instead of "Members" template even though the activity permalink page is located within the members template hierarchy. It seemed a better fit. I can move this down as sub-category of "08. Single member" if you'd prefer. 

https://github.com/paulgibbs/turtleshell/issues/8#issuecomment-9476611
